### PR TITLE
Fix JSON-LD structure of the htmlParser

### DIFF
--- a/src/main/java/net/yacy/document/parser/html/Tag.java
+++ b/src/main/java/net/yacy/document/parser/html/Tag.java
@@ -341,7 +341,7 @@ public class Tag {
                 // For RDFa and microdata the content property key is the same!
                 content_text = this.opts.getProperty("content");
             } else if ((this.getName().equals("a")) && this.opts.containsKey("href")) {
-                // For anchor tags it is common to take the 'content'from `href` attribute.
+                // For anchor tags it is common to take the 'content' from `href` attribute.
                 content_text = this.opts.getProperty("href");
             } else {
                 // If no content is given within the tag properties, either the content of the tag or an embedded json-ld node is used.

--- a/src/main/java/net/yacy/document/parser/html/Tag.java
+++ b/src/main/java/net/yacy/document/parser/html/Tag.java
@@ -329,7 +329,7 @@ public class Tag {
                 if (!json.has(itemprop)) {
                     json.put(itemprop, new JSONObject(true));
                 }
-                json.getJSONObject(itemprop).put(JsonLD.TYPE, typeof);                
+                json.getJSONObject(itemprop).put(JsonLD.TYPE, typeof);
             }
         }
         
@@ -340,6 +340,9 @@ public class Tag {
             if (this.opts.containsKey("content")) {
                 // For RDFa and microdata the content property key is the same!
                 content_text = this.opts.getProperty("content");
+            } else if ((this.getName().equals("a")) && this.opts.containsKey("href")) {
+                // For anchor tags it is common to take the 'content'from `href` attribute.
+                content_text = this.opts.getProperty("href");
             } else {
                 // If no content is given within the tag properties, either the content of the tag or an embedded json-ld node is used.
                 // Embedded json-ld nodes are handled with the addChildToParent method. This here is for leaf objects.

--- a/src/main/java/net/yacy/document/parser/html/Tag.java
+++ b/src/main/java/net/yacy/document/parser/html/Tag.java
@@ -227,7 +227,7 @@ public class Tag {
      */
     public void addChildToParent(Tag child) {
         
-        if (this.ld.graphSize() == 0 || (child.ld.hasContext() && !this.ld.hasContext())) {
+        if (this.ld.graphSize() == 0 && (child.ld.hasContext() && !this.ld.hasContext())) {
             child.learnLdFromProperties();
             this.ld = child.ld;
             return;

--- a/src/main/java/net/yacy/document/parser/html/Tag.java
+++ b/src/main/java/net/yacy/document/parser/html/Tag.java
@@ -23,6 +23,8 @@ import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
+import java.util.Arrays;
+import java.util.List;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -150,6 +152,8 @@ public class Tag {
             this.type = type;
         }
     }
+
+    private List<String> hrefAllowedTags = Arrays.asList("a", "area", "base", "link");
 
     
     public Tag(final String name, final Properties opts) {
@@ -301,8 +305,6 @@ public class Tag {
     }
     
     public void learnLdFromProperties() {
-
-        
         String itemtype = this.opts.getProperty("itemtype", null); // microdata
         if (itemtype != null) {
             System.out.println("**CONTEXT " + itemtype);
@@ -340,7 +342,7 @@ public class Tag {
             if (this.opts.containsKey("content")) {
                 // For RDFa and microdata the content property key is the same!
                 content_text = this.opts.getProperty("content");
-            } else if ((this.getName().equals("a")) && this.opts.containsKey("href")) {
+            } else if (hrefAllowedTags.contains(this.getName()) && this.opts.containsKey("href")) {
                 // For anchor tags it is common to take the 'content' from `href` attribute.
                 content_text = this.opts.getProperty("href");
             } else {

--- a/src/main/java/net/yacy/document/parser/html/Tokenizer.java
+++ b/src/main/java/net/yacy/document/parser/html/Tokenizer.java
@@ -414,7 +414,6 @@ public final class Tokenizer extends Writer {
                 char[] childTagText = childTag.toChars(quotechar);
                 this.topmostTag.appendToContent(childTagText);
                 // - append microdata
-                this.topmostTag.learnLdFromProperties();
                 this.topmostTag.addChildToParent(childTag);
             } else {
                 childTag.learnLdFromProperties();

--- a/src/main/java/net/yacy/document/parser/html/Tokenizer.java
+++ b/src/main/java/net/yacy/document/parser/html/Tokenizer.java
@@ -414,6 +414,7 @@ public final class Tokenizer extends Writer {
                 char[] childTagText = childTag.toChars(quotechar);
                 this.topmostTag.appendToContent(childTagText);
                 // - append microdata
+                this.topmostTag.learnLdFromProperties();
                 this.topmostTag.addChildToParent(childTag);
             } else {
                 childTag.learnLdFromProperties();


### PR DESCRIPTION
This pull request 
* removes whitespaces at the end of a line
* fixes parent/child relation building of the json-ld structure
* enables the scraper to read the microdata predicate from `href` attributes in anchor tags (`<a>`)