### PR TITLE
don't use invalid meta tag for last modified

### DIFF
--- a/src/main/java/net/yacy/document/parser/html/Scraper.java
+++ b/src/main/java/net/yacy/document/parser/html/Scraper.java
@@ -1058,10 +1058,6 @@ public class Scraper {
         content = this.metas.get("dc:date");
         if (content != null) try {return ISO8601Formatter.FORMATTER.parse(content, this.timezoneOffset).getTime();} catch (ParseException e) {}
 
-        // <meta http-equiv="last-modified" content="YYYY-MM-DD" />
-        content = this.metas.get("last-modified");
-        if (content != null) try {return ISO8601Formatter.FORMATTER.parse(content, this.timezoneOffset).getTime();} catch (ParseException e) {}
-
         return new Date();
     }
 


### PR DESCRIPTION
We experienced some issues on a website, that utilizes the`<meta>` tag with the following specs:


```html
<meta name="last-modified" content="1648426480">
```

Due to the pinning in the scraper, yacy parses the date as malformed date which results in an error while saving the document in elasticsearch.

Since the specification (https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv) does not support the `last-modified` variant for `http-equiv`, YaCy should not blindly parse the tag if it is available.