### PR TITLE
Only process absolute URLs for base tags

### DIFF
--- a/src/main/java/net/yacy/document/parser/html/Scraper.java
+++ b/src/main/java/net/yacy/document/parser/html/Scraper.java
@@ -426,7 +426,13 @@ public class Scraper {
             this.evaluationScores.match(Element.imgpath, src);
         } else if(tag.hasName("base")) {
             try {
-                this.root = new MultiProtocolURL(tag.getProperty("href", EMPTY_STRING));
+                String href = tag.getProperty("href", EMPTY_STRING);
+                href = CharacterCoding.html2unicode(href);
+
+                AnchorURL url;
+                if ((href.length() > 0) && ((url = absolutePath(href)) != null)) {
+                    this.root = new MultiProtocolURL(url.toString());
+                }
             } catch (final MalformedURLException e) {}
         } else if (tag.hasName("frame")) {
             final AnchorURL src = absolutePath(tag.getProperty("src", EMPTY_STRING));


### PR DESCRIPTION
When HTML contains a base tag with an relative URL and an absolute path (e.g. `<base href="/" />`, `MultiProtocolURL` will set the root url to `file://` because of the following code.

```java
        if (url.length() > 0 && url.charAt(0) == '/') {
            // maybe a unix/linux absolute path
            url = "file://" + url;
        }
``` 

**java.net.yacy.grid.tools.MultiProtocolURL:190**

Since relative URLs seem to be allowed (at least in the MDN spec https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base#attr-href) we need to ensure, that links are further prefixed with the correct domain and not the `file://`- protocol.

This pull request introduces a sanitisation of the previous described issue in a similar way like the `a` tag ensures the validity. It converts relative URL to absolute ones and then creates a `MultiProtocolURL` out of it.